### PR TITLE
Prima Commedy Central renamed to Paramount NETWORK

### DIFF
--- a/WebGrab++.config.xml
+++ b/WebGrab++.config.xml
@@ -32,7 +32,7 @@
 <channel update="i" site="horizon.tv" site_id="CZ/ces_546677286985__https://wp6-images-cz-dynamic.horizon.tv/Logos/5073.f.png" xmltv_id="Nova-Action-HD">Nova Action HD</channel>
 <channel update="i" site="horizon.tv" site_id="CZ/ces_711694375046__https://wp27-images-cz-dynamic.horizon.tv/Logos/8098.f.png" xmltv_id="Nova-Gold-HD">Nova Gold HD</channel>
 <channel update="i" site="horizon.tv" site_id="CZ/ces_711693863134__https://wp22-images-cz-dynamic.horizon.tv/Logos/8097.f.png" xmltv_id="Nova-2-HD">Nova 2 HD</channel>
-<channel update="i" site="horizon.tv" site_id="CZ/ces_691489318956__https://wp24-images-cz-dynamic.horizon.tv/Logos/769677.f.png" xmltv_id="Paramount-Network">Paramount NETWORK</channel>
+<channel update="i" site="horizon.tv" site_id="CZ/ces_691489318956__https://wp24-images-cz-dynamic.horizon.tv/Logos/769677.f.png" xmltv_id="Paramount-Network">Paramount Network</channel>
 <channel update="i" site="horizon.tv" site_id="CZ/ces_546677287017__https://wp19-images-cz-dynamic.horizon.tv/Logos/5134.f.png" xmltv_id="Prima-COOL-HD">Prima COOL HD</channel>
 <channel update="i" site="horizon.tv" site_id="CZ/ces_546676775215__https://wp22-images-cz-dynamic.horizon.tv/Logos/5139.f.png" xmltv_id="Prima-ZOOM-HD">Prima ZOOM HD</channel>
 <channel update="i" site="horizon.tv" site_id="CZ/ces_711693863137__https://wp19-images-cz-dynamic.horizon.tv/Logos/769702.f.png" xmltv_id="Prima-love-HD">Prima love HD</channel>

--- a/WebGrab++.config.xml
+++ b/WebGrab++.config.xml
@@ -32,7 +32,7 @@
 <channel update="i" site="horizon.tv" site_id="CZ/ces_546677286985__https://wp6-images-cz-dynamic.horizon.tv/Logos/5073.f.png" xmltv_id="Nova-Action-HD">Nova Action HD</channel>
 <channel update="i" site="horizon.tv" site_id="CZ/ces_711694375046__https://wp27-images-cz-dynamic.horizon.tv/Logos/8098.f.png" xmltv_id="Nova-Gold-HD">Nova Gold HD</channel>
 <channel update="i" site="horizon.tv" site_id="CZ/ces_711693863134__https://wp22-images-cz-dynamic.horizon.tv/Logos/8097.f.png" xmltv_id="Nova-2-HD">Nova 2 HD</channel>
-<channel update="i" site="horizon.tv" site_id="CZ/ces_691489318956__https://wp24-images-cz-dynamic.horizon.tv/Logos/769677.f.png" xmltv_id="Prima-Comedy -entral">Prima Comedy Central</channel>
+<channel update="i" site="horizon.tv" site_id="CZ/ces_691489318956__https://wp24-images-cz-dynamic.horizon.tv/Logos/769677.f.png" xmltv_id="Paramount-Network">Paramount NETWORK</channel>
 <channel update="i" site="horizon.tv" site_id="CZ/ces_546677287017__https://wp19-images-cz-dynamic.horizon.tv/Logos/5134.f.png" xmltv_id="Prima-COOL-HD">Prima COOL HD</channel>
 <channel update="i" site="horizon.tv" site_id="CZ/ces_546676775215__https://wp22-images-cz-dynamic.horizon.tv/Logos/5139.f.png" xmltv_id="Prima-ZOOM-HD">Prima ZOOM HD</channel>
 <channel update="i" site="horizon.tv" site_id="CZ/ces_711693863137__https://wp19-images-cz-dynamic.horizon.tv/Logos/769702.f.png" xmltv_id="Prima-love-HD">Prima love HD</channel>


### PR DESCRIPTION
More info: https://www.idnes.cz/zpravy/mediahub/prima-comedy-central-zmena-na-paramount-network.A201207_085817_mediahub_jpl